### PR TITLE
Load Stripe JS-file asynchronously

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   
   contentFor: function(type) {
     if (type === 'body') {
-      return '<script src="https://checkout.stripe.com/checkout.js"></script>';
+      return '<script src="https://checkout.stripe.com/checkout.js" async="true"></script>';
     }
   },
 };


### PR DESCRIPTION
In order not to delay the rendering, I think it's better to let the browser download Stripe's JS-file asynchronously if it can.

This shouldn't have any negative consequences when loading the pageAFAIK, since Stripe checkout isn't necessary before the user clicks the button.